### PR TITLE
add timeout so auto-replay is visible, improve replayer restart conditions

### DIFF
--- a/src/components/avatar-recorder.js
+++ b/src/components/avatar-recorder.js
@@ -9,6 +9,7 @@ AFRAME.registerComponent('avatar-recorder', {
     autoRecord: {default: false},
     autoPlay: {default: true},
     localStorage: {default: true},
+    loop: {default: true},
     binaryFormat: {default: false}
   },
 
@@ -37,13 +38,16 @@ AFRAME.registerComponent('avatar-recorder', {
     }
   },
 
-  playRecording: function () {
-    var data;
+  replayRecording: function () {
+    var data = this.data;
     var el = this.el;
+    var replayData;
+
     data = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY)) || this.recordingData;
     if (!data) { return; }
+
     log('Replaying recording.');
-    el.setAttribute('avatar-replayer', {loop: true});
+    el.setAttribute('avatar-replayer', {loop: data.loop});
     el.components['avatar-replayer'].startReplaying(data);
   },
 
@@ -78,7 +82,15 @@ AFRAME.registerComponent('avatar-recorder', {
   },
 
   play: function () {
-    if (this.data.autoPlay) { this.playRecording(); }
+    var self = this;
+    var sceneEl = this.el;
+
+    if (this.data.autoPlay) {
+      // Add timeout to let the scene load a bit before replaying.
+      setTimeout(function () {
+        self.replayRecording();
+      }, 500);
+    }
     window.addEventListener('keydown', this.onKeyDown);
   },
 
@@ -122,7 +134,7 @@ AFRAME.registerComponent('avatar-recorder', {
     if (avatarPlayer.isReplaying) {
       this.stopReplaying();
     } else {
-      this.playRecording();
+      this.replayRecording();
     }
   },
 
@@ -158,7 +170,7 @@ AFRAME.registerComponent('avatar-recorder', {
       trackedControllerEls[id].components['motion-capture-recorder'].stopRecording();
     });
     this.saveRecording();
-    if (this.data.autoPlay) { this.playRecording(); }
+    if (this.data.autoPlay) { this.replayRecording(); }
   },
 
   getJSONData: function () {

--- a/src/components/motion-capture-recorder.js
+++ b/src/components/motion-capture-recorder.js
@@ -13,8 +13,9 @@ var EVENTS_DECODE = {
   0: 'axismove',
   1: 'buttonchanged',
   2: 'buttondown',
-  3: 'touchstart',
-  4: 'touchend'
+  3: 'buttonup',
+  4: 'touchstart',
+  5: 'touchend'
 };
 
 AFRAME.registerComponent('motion-capture-recorder', {


### PR DESCRIPTION
**Behavior Changes:**
 
- Loop by default. Pass the loop property down from recorder to replayer.
- Properly do restart conditions after each recording whether looping or not looping.
- More logging.

**Bug Fixes:**

- Autoplay wasn't work on Nightly. Adding a `setTimeout` helped. I think it's because of the timestamp issues or because it was trying to play while still loading?