### PR TITLE
bug fixes, play from query parameter, smaller recording files (fixes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,21 @@ development ergonomics or any other applications of motion capture.
 
 ### Usage
 
-#### WebVR Recording
+#### Avatar Recording
 
-Set the `avatar-recorder` on the scene. Make sure your controllers have `id`s.
-Then hit `<space>` to toggle recording. A JSON will automatically be downloaded
-once the recording finishes.
+An "avatar" is the representation of a user. Use the `avatar-recorder` to
+record headset and tracked controller poses as well as controller events (i.e.,
+button presses and touches).
+
+1. Set the `avatar-recorder` component on the `<a-scene>` element.
+2. Make sure your controllers have `id`s.
+3. Hit `<space>` to start recording.
+4. Record movements and controller events.
+5. Hit `<space>>` again to stop recording.
+6. The recording will play from `localStorage`. Hit `<ctrl> + <shift> + s` to save the
+   recording to a file.
+
+Hit `c` on the keyboard to clear the recording from `localStorage`.
 
 ```html
 <a-scene avatar-recorder>
@@ -20,10 +30,37 @@ once the recording finishes.
 </a-scene>
 ```
 
-#### WebVR Replaying
+#### Avatar Replaying
 
-Specify the path to a captured WebVR recording JSON file. Hit `p` to toggle
-playback.
+The `avatar-recorder` will automatically set the `avatar-replayer` component.
+Though we can specify the `avatar-replayer` explicitly if we want to configure
+it or if we don't need recording (i.e., production):
+
+```html
+<a-scene avatar-replayer="src: recording.json; loop: true">
+  <a-entity id="controller1" hand-controls"></a-entity>
+  <a-entity id="controller2" hand-controls"></a-entity>
+</a-scene>
+```
+
+##### From localStorage
+
+By default, the `avatar-recorder` will save the recording into `localStorage`
+which the `avatar-replayer` will replay from by default.
+
+Hit `p` to toggle playback.
+
+##### From File
+
+We can specify the path to a recording file via the `avatar-recording` **query
+parameter** in the URL:
+
+```html
+https://foo.bar?avatar-recording=path/to/recording.json
+https://foo.bar?avatar-recording=path/to/anotherRecording.json
+```
+
+Or we can specify the path to a recording file via the `src` property:
 
 ```html
 <a-scene avatar-replayer="src: recording.json">
@@ -36,37 +73,41 @@ playback.
 
 #### Keyboard Shortcuts
 
-| Key   | Description                                   |
-|-------|-----------------------------------------------|
-| space | Toggle recording.                             |
-| c     | Clear recording from localStorage and memory. |
-| p     | Toggle replaying.                             |
+| Key          | Description                                   |
+|--------------|-----------------------------------------------|
+| space        | Toggle recording.                             |
+| c            | Clear recording from localStorage and memory. |
+| p            | Toggle replaying.                             |
+| ctrl/shift/s | Save recording to file.                       |
 
 #### avatar-recorder
 
-| Property     | Description | Default Value |
-| --------     | ----------- | ------------- |
-| autoPlay     |             | true          |
-| autoRecord   |             | false         |
-| binaryFormat |             | false         |
-| localStorage |             | false         |
+| Property      | Description | Default Value |
+| --------      | ----------- | ------------- |
+| autoPlay      |             | true          |
+| autoPlayDelay |             | 500           |
+| autoRecord    |             | false         |
+| binaryFormat  |             | false         |
+| localStorage  |             | true          |
 
 #### avatar-replayer
 
 | Property      | Description | Default Value |
 | --------      | ----------- | ------------- |
-| loop          |             | false         |
+| autoPlay      |             | true          |
+| loop          |             | true          |
 | src           |             | ''            |
 | spectatorMode |             | false         |
 
 #### motion-capture-replayer
 
-| Property   | Description | Default Value |
-| --------   | ----------- | ------------- |
-| enabled    |             | true          |
-| loop       |             | true          |
-| recorderEl | Selector.   | null          |
-| src        |             | ''            |
+| Property        | Description | Default Value |
+| --------        | ----------- | ------------- |
+| enabled         |             | true          |
+| loop            |             | true          |
+| recorderEl      | Selector.   | null          |
+| src             |             | ''            |
+| spectatorCamera |             | false         |
 
 #### motion-capture-recorder
 

--- a/src/components/avatar-recorder.js
+++ b/src/components/avatar-recorder.js
@@ -10,7 +10,6 @@ AFRAME.registerComponent('avatar-recorder', {
     autoPlay: {default: true},
     autoPlayDelay: {default: 500},
     localStorage: {default: true},
-    loop: {default: true},
     binaryFormat: {default: false}
   },
 
@@ -39,19 +38,38 @@ AFRAME.registerComponent('avatar-recorder', {
     }
   },
 
+  /**
+   * Replay recording immediately after recording.
+   * Differs from `autoPlayRecording` in that it uses recorded `this.recordingData` and
+   * overrides any recording sources that `avatar-replayer` may have defined.
+   */
   replayRecording: function () {
-    var data = this.data;
-    var el = this.el;
-    var replayData;
-
-    data = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY)) || this.recordingData;
-    if (!data) { return; }
-
-    log('Replaying recording.');
-    el.setAttribute('avatar-replayer', {loop: data.loop});
-    el.components['avatar-replayer'].startReplaying(data);
+    var sceneEl = this.el;
+    log('Replaying recording just taken.');
+    sceneEl.setAttribute('avatar-replayer', {autoPlay: false});
+    sceneEl.components['avatar-replayer'].startReplaying(this.recordingData);
   },
 
+  /**
+   * Replay recording on initialization as `autoPlay`.
+   * Differs from `replayRecording` in that this lets `avatar-replayer` decide where to
+   * source its recording.
+   */
+  autoReplayRecording: function () {
+    var data = this.data;
+    var sceneEl = this.el;
+
+    if (!data.autoPlay) { return; }
+
+    // Add timeout to let the scene load a bit before replaying.
+    setTimeout(function () {
+      sceneEl.setAttribute('avatar-replayer', {autoPlay: true});
+    }, data.autoPlayDelay);
+  },
+
+  /**
+   * Tell `avatar-replayer` to stop recording.
+   */
   stopReplaying: function () {
     var avatarPlayer = this.el.components['avatar-replayer'];
     if (!avatarPlayer) { return; }
@@ -83,16 +101,8 @@ AFRAME.registerComponent('avatar-recorder', {
   },
 
   play: function () {
-    var self = this;
-    var sceneEl = this.el;
-
-    if (this.data.autoPlay) {
-      // Add timeout to let the scene load a bit before replaying.
-      setTimeout(function () {
-        self.replayRecording();
-      }, this.data.autoPlayDelay);
-    }
     window.addEventListener('keydown', this.onKeyDown);
+    this.autoReplayRecording();
   },
 
   pause: function () {
@@ -218,7 +228,7 @@ AFRAME.registerComponent('avatar-recorder', {
     var type = this.data.binaryFormat ? 'application/octet-binary' : 'application/json';
     var blob = new Blob([jsonData], {type: type});
     var url = URL.createObjectURL(blob);
-    var fileName = 'recording.json';
+    var fileName = 'recording-' + document.title.toLowerCase() + '.json';
     var aEl = document.createElement('a');
     aEl.href = url;
     aEl.setAttribute('download', fileName);

--- a/src/components/avatar-recorder.js
+++ b/src/components/avatar-recorder.js
@@ -118,6 +118,7 @@ AFRAME.registerComponent('avatar-recorder', {
    */
   onKeyDown: function (evt) {
     var key = evt.keyCode;
+    var replayer = this.el.components['avatar-replayer'];
 
     // space.
     if (key === 32) {
@@ -141,7 +142,11 @@ AFRAME.registerComponent('avatar-recorder', {
 
     // ctrl/shift/s.
     if (evt.ctrlKey && evt.shiftKey && key === 83) {
-      this.saveRecordingFile(this.getJSONData());
+      if (replayer && replayer.replayData) {
+        this.saveRecordingFile(replayer.replayData);
+      } else {
+        this.saveRecordingFile(this.getJSONData());
+      }
     }
   },
 

--- a/src/components/avatar-recorder.js
+++ b/src/components/avatar-recorder.js
@@ -8,6 +8,7 @@ AFRAME.registerComponent('avatar-recorder', {
   schema: {
     autoRecord: {default: false},
     autoPlay: {default: true},
+    autoPlayDelay: {default: 500},
     localStorage: {default: true},
     loop: {default: true},
     binaryFormat: {default: false}
@@ -89,7 +90,7 @@ AFRAME.registerComponent('avatar-recorder', {
       // Add timeout to let the scene load a bit before replaying.
       setTimeout(function () {
         self.replayRecording();
-      }, 500);
+      }, this.data.autoPlayDelay);
     }
     window.addEventListener('keydown', this.onKeyDown);
   },

--- a/src/components/avatar-recorder.js
+++ b/src/components/avatar-recorder.js
@@ -100,28 +100,38 @@ AFRAME.registerComponent('avatar-recorder', {
   },
 
   /**
-   * space = toggle recording, p = stop playing, c = clear local storage
+   * Keyboard shortcuts.
+   * space: toggle recording.
+   * p: toggle replaying.
+   * c: clear local storage.
+   * ctrl/shift/s: save recording to file.
    */
   onKeyDown: function (evt) {
     var key = evt.keyCode;
-    if (key !== 32 && key !== 80 && key !== 67) { return; }
-    switch (key) {
-      case 32: {
-        this.toggleRecording();
-        break;
-      }
 
-      case 80: {
-        this.toggleReplaying();
-        break;
-      }
+    // space.
+    if (key === 32) {
+      this.toggleRecording();
+      return;
+    }
 
-      case 67: {
-        log('Recording cleared from localStorage.');
-        this.recordingData = null;
-        localStorage.removeItem(LOCALSTORAGE_KEY);
-        break;
-      }
+    // p.
+    if (key === 80) {
+      this.toggleReplaying();
+      return;
+    }
+
+    // c.
+    if (key === 67) {
+      log('Recording cleared from localStorage.');
+      this.recordingData = null;
+      localStorage.removeItem(LOCALSTORAGE_KEY);
+      return;
+    }
+
+    // ctrl/shift/s.
+    if (evt.ctrlKey && evt.shiftKey && key === 83) {
+      this.saveRecordingFile(this.getJSONData());
     }
   },
 
@@ -208,7 +218,7 @@ AFRAME.registerComponent('avatar-recorder', {
     var type = this.data.binaryFormat ? 'application/octet-binary' : 'application/json';
     var blob = new Blob([jsonData], {type: type});
     var url = URL.createObjectURL(blob);
-    var fileName = 'player-recording-' + document.title + '-' + Date.now() + '.json';
+    var fileName = 'recording.json';
     var aEl = document.createElement('a');
     aEl.href = url;
     aEl.setAttribute('download', fileName);

--- a/src/components/avatar-replayer.js
+++ b/src/components/avatar-replayer.js
@@ -117,14 +117,16 @@ AFRAME.registerComponent('avatar-replayer', {
     var puppetEl;
     var sceneEl = this.el;
 
-    this.recordingData = replayData;
-    this.isReplaying = true;
+    // Wait for camera.
     if (!this.el.camera) {
       this.el.addEventListener('camera-set-active', function () {
         self.startReplaying(replayData);
       });
       return;
     }
+
+    this.replayData = replayData;
+    this.isReplaying = true;
 
     Object.keys(replayData).forEach(function setPlayer (key) {
       var puppetEl;
@@ -148,14 +150,15 @@ AFRAME.registerComponent('avatar-replayer', {
     });
 
     this.initSpectatorCamera();
+    sceneEl.emit('avatarreplayerstart');
   },
 
   stopReplaying: function () {
     var keys;
     var self = this;
-    if (!this.isReplaying || !this.recordingData) { return; }
+    if (!this.isReplaying || !this.replayData) { return; }
     this.isReplaying = false;
-    keys = Object.keys(this.recordingData);
+    keys = Object.keys(this.replayData);
     keys.forEach(function (key) {
       if (key === 'camera') {
         self.el.camera.el.components['motion-capture-replayer'].stopReplaying();

--- a/src/components/avatar-replayer.js
+++ b/src/components/avatar-replayer.js
@@ -191,7 +191,10 @@ AFRAME.registerComponent('avatar-replayer', {
       }
 
       puppetEl.setAttribute('motion-capture-replayer', {loop: data.loop});
-      puppetEl.components['motion-capture-replayer'].startReplaying(replayData[key]);
+
+      // Clone because detail objects will be modified by browser.
+      puppetEl.components['motion-capture-replayer'].startReplaying(
+        AFRAME.utils.clone(replayData[key]));
     });
 
     this.initSpectatorCamera();

--- a/src/components/avatar-replayer.js
+++ b/src/components/avatar-replayer.js
@@ -117,7 +117,7 @@ AFRAME.registerComponent('avatar-replayer', {
     var puppetEl;
     var sceneEl = this.el;
 
-    this.recordingreplayData = replayData;
+    this.recordingData = replayData;
     this.isReplaying = true;
     if (!this.el.camera) {
       this.el.addEventListener('camera-set-active', function () {

--- a/src/components/motion-capture-recorder.js
+++ b/src/components/motion-capture-recorder.js
@@ -1,4 +1,5 @@
 /* global AFRAME, THREE */
+var log = AFRAME.utils.debug('aframe-motion-capture:motion-capture-recorder:info');
 
 var EVENTS = {
   axismove: {id: 0, props: ['id', 'axis']},
@@ -38,12 +39,15 @@ AFRAME.registerComponent('motion-capture-recorder', {
     var el = this.el;
     this.recordEvent = this.recordEvent.bind(this);
     el.addEventListener('axismove', this.recordEvent);
-    el.addEventListener('buttonchanged', this.onTriggerChanged.bind(this));
     el.addEventListener('buttonchanged', this.recordEvent);
     el.addEventListener('buttonup', this.recordEvent);
     el.addEventListener('buttondown', this.recordEvent);
     el.addEventListener('touchstart', this.recordEvent);
     el.addEventListener('touchend', this.recordEvent);
+
+    // TODO: Introduce back in, but decoupled and configurable.
+    // For hand-controlled recording, but not desired for avatar recording.
+    // el.addEventListener('buttonchanged', this.onTriggerChanged.bind(this));
   },
 
   recordEvent: function (evt) {
@@ -66,8 +70,10 @@ AFRAME.registerComponent('motion-capture-recorder', {
     var data = this.data;
     var value;
     if (!data.enabled || data.autoRecord) { return; }
-    // Not Trigger
+
+    // Not trigger.
     if (evt.detail.id !== 1) { return; }
+
     value = evt.detail.state.value;
     if (value <= 0.1) {
       if (this.isRecording) { this.stopRecording(); }
@@ -169,6 +175,7 @@ AFRAME.registerComponent('motion-capture-recorder', {
   stopRecording: function () {
     var el = this.el;
     if (!this.isRecording) { return; }
+    log('Recorded ' + this.recordedPoses.length + ' poses.', el);
     el.emit('strokeended', {poses: this.recordedPoses});
     this.isRecording = false;
     if (!this.data.visibleStroke || this.data.persistStroke) { return; }

--- a/src/components/motion-capture-recorder.js
+++ b/src/components/motion-capture-recorder.js
@@ -56,6 +56,10 @@ AFRAME.registerComponent('motion-capture-recorder', {
 
     detail = {};
     EVENTS[evt.type].props.forEach(function buildDetail (propName) {
+      if (propName === 'state' && evt.detail.state !== undefined) {
+        detail.state = {value: evt.detail.state.value};
+        return;
+      }
       detail[propName] = evt.detail[propName];
     });
 
@@ -85,8 +89,8 @@ AFRAME.registerComponent('motion-capture-recorder', {
   getJSONData: function () {
     if (!this.recordedPoses) { return; }
     return {
-      poses: this.system.getStrokeJSON(this.recordedPoses),
-      events: this.recordedEvents
+      poses: this.system.getStrokeJSON(this.recordedPoses) || [],
+      events: this.recordedEvents || []
     };
   },
 

--- a/src/components/motion-capture-replayer.js
+++ b/src/components/motion-capture-replayer.js
@@ -87,6 +87,7 @@ AFRAME.registerComponent('motion-capture-replayer', {
   },
 
   startReplayingPoses: function (poses) {
+    if (!poses.length) { return; }
     this.isReplaying = true;
     this.currentPoseIndex = 0;
     this.replayingPoses = poses;
@@ -95,6 +96,7 @@ AFRAME.registerComponent('motion-capture-replayer', {
 
   startReplayingEvents: function (events) {
     var firstEvent;
+    if (!events.length) { return; }
     this.isReplaying = true;
     this.currentEventIndex = 0;
     this.replayingEvents = events;

--- a/src/components/motion-capture-replayer.js
+++ b/src/components/motion-capture-replayer.js
@@ -137,14 +137,16 @@ AFRAME.registerComponent('motion-capture-replayer', {
       currentEvent = this.playingEvents[this.currentEventIndex];
     }
 
-    // End of recording reached with loop. Restore pose, reset state, restart.
-    if (this.data.loop && this.currentPoseIndex >= playingPoses.length) {
-      log('End of recording reached. Looping replay.');
-      this.restart();
-    }
+    // End of recording reached.
+    if (this.currentPoseIndex >= playingPoses.length) {
+      // With loop. Restore pose, reset state, restart.
+      if (this.data.loop) {
+        log('End of recording reached. Looping replay.');
+        this.restart();
+        return;
+      }
 
-    // End of recording reached without loop. Stop replaying, restore pose, reset state.
-    if (!this.data.loop && this.currentPoseIndex >= playingPoses.length) {
+      // Without loop. Stop replaying, restore pose, reset state.
       log('End of recording reached.', this.el);
       this.stopReplaying();
       this.restart();

--- a/tests/assets/test.json
+++ b/tests/assets/test.json
@@ -1,0 +1,1 @@
+{"camera":{"poses":[{"position":{"x":1,"y":2,"z":3},"rotation":{"x":30,"y":60,"z":90},"timestamp":100}],"events":[]}}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -147,6 +147,22 @@ suite('avatar-recorder', function () {
       });
     });
   });
+
+  test('loads recording from file via query parameter w/ autoplay', function (done) {
+    sceneEl.setAttribute('avatar-replayer', {autoPlay: false});
+    replayComponent = sceneEl.components['avatar-replayer'];
+
+    this.sinon.stub(replayComponent, 'getSrcFromSearchParam', function () {
+      return '/base/tests/assets/test.json';
+    });
+
+    sceneEl.addEventListener('avatarreplayerstart', () => {
+      assert.ok(replayComponent.isReplaying);
+      assert.ok(replayComponent.replayData);
+      done();
+    });
+    sceneEl.setAttribute('avatar-recorder', {autoPlay: true});
+  });
 });
 
 suite('avatar-recorder (replay from localStorage)', function () {
@@ -172,7 +188,7 @@ suite('avatar-recorder (replay from localStorage)', function () {
         camera: {poses: [{timestamp: 0}], events: []},
       }));
       setTimeout(() => {
-        sceneEl.setAttribute('avatar-recorder', 'autoPlay: true; autoPlayDelay: 0');
+        sceneEl.setAttribute('avatar-recorder', {autoPlay: true, autoPlayDelay: 0});
         setTimeout(() => {
           assert.ok(sceneEl.components['avatar-replayer'], 'Replayer is set');
           assert.ok(sceneEl.components['avatar-replayer'].isReplaying);
@@ -183,13 +199,13 @@ suite('avatar-recorder (replay from localStorage)', function () {
   });
 
   test('autoPlays from localStorage with replayer set', function (done) {
-    sceneEl.setAttribute('avatar-replayer', '');
-    const startReplayingSpy = this.sinon.spy(sceneEl.components['avatar-replayer'],
-                                             'startReplaying');
-
     localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify({
       camera: {poses: [{timestamp: 0}], events: []},
     }));
+
+    sceneEl.setAttribute('avatar-replayer', '');
+    const startReplayingSpy = this.sinon.spy(sceneEl.components['avatar-replayer'],
+                                             'startReplaying');
 
     sceneEl.setAttribute('avatar-recorder', {autoPlay: true, autoPlayDelay: 0});
     setTimeout(() => {
@@ -276,7 +292,7 @@ suite('avatar-replayer', function () {
     });
   });
 
-  test('loads recording from external file', (done) => {
+  test('loads recording from file', function (done) {
     sceneEl.addEventListener('avatarreplayerstart', () => {
       assert.ok(component.isReplaying);
       assert.ok(component.replayData);
@@ -286,6 +302,23 @@ suite('avatar-replayer', function () {
       src: '/base/tests/assets/test.json',
       loop: false
     });
+  });
+
+  test('loads recording from file via query parameter', function (done) {
+    this.sinon.stub(component, 'getSrcFromSearchParam', function () {
+      return '/base/tests/assets/test.json';
+    });
+
+    sceneEl.addEventListener('avatarreplayerstart', () => {
+      assert.ok(component.isReplaying, 'Is replaying.');
+      assert.ok(component.replayData, 'Has replay data.');
+      done();
+    });
+
+    sceneEl.setAttribute('avatar-replayer', {autoPlay: true, loop: false});
+    assert.notOk(component.isReplaying, 'Not replaying yet.');
+    assert.notOk(component.replayData, 'No replay data yet.');
+
   });
 });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -172,7 +172,7 @@ suite('avatar-recorder (replay from localStorage)', function () {
         camera: {poses: [{timestamp: 0}], events: []},
       }));
       setTimeout(() => {
-        sceneEl.setAttribute('avatar-recorder', 'autoPlay: true');
+        sceneEl.setAttribute('avatar-recorder', 'autoPlay: true; autoPlayDelay: 0');
         setTimeout(() => {
           assert.ok(sceneEl.components['avatar-replayer'], 'Replayer is set');
           assert.ok(sceneEl.components['avatar-replayer'].isReplaying);
@@ -183,7 +183,7 @@ suite('avatar-recorder (replay from localStorage)', function () {
   });
 
   test('autoPlays from localStorage with replayer set', function (done) {
-    sceneEl.setAttribute('avatar-replayer', 'autoPlay: true');
+    sceneEl.setAttribute('avatar-replayer', '');
     const startReplayingSpy = this.sinon.spy(sceneEl.components['avatar-replayer'],
                                              'startReplaying');
 
@@ -191,12 +191,12 @@ suite('avatar-recorder (replay from localStorage)', function () {
       camera: {poses: [{timestamp: 0}], events: []},
     }));
 
-    sceneEl.setAttribute('avatar-recorder', 'autoPlay: true');
+    sceneEl.setAttribute('avatar-recorder', {autoPlay: true, autoPlayDelay: 0});
     setTimeout(() => {
       assert.ok(startReplayingSpy.called);
       assert.ok(startReplayingSpy.getCalls()[0].args[0].camera.poses);
       done();
-    });
+    }, 50);
   });
 
   test('does not autoPlay if nothing in localStorage', function (done) {
@@ -449,7 +449,7 @@ suite('motion-capture-replayer', function () {
       component = el.components['motion-capture-replayer'];
       done();
     });
-    el.setAttribute('motion-capture-replayer', 'loop: false');
+    el.setAttribute('motion-capture-replayer', {loop: false});
   });
 
   test('plays poses', function () {
@@ -499,11 +499,18 @@ suite('motion-capture-replayer', function () {
       done();
     });
 
-    component.startReplayingEvents([
-      {timestamp: 100, name: 'buttondown', detail: {id: 'foo', state: true}},
-      {timestamp: 200, name: 'axismove', detail: {id: 'bar', axis: {x: 1, y: 1}}},
-      {timestamp: 250, name: 'touchend', detail: {id: 'baz', state: true}}
-    ]);
+    component.startReplaying({
+      events: [
+        {timestamp: 100, name: 'buttondown', detail: {id: 'foo', state: true}},
+        {timestamp: 200, name: 'axismove', detail: {id: 'bar', axis: {x: 1, y: 1}}},
+        {timestamp: 250, name: 'touchend', detail: {id: 'baz', state: true}}
+      ],
+      poses: [
+        {timestamp: 100, position: {}, rotation: {}},
+        {timestamp: 200, position: {}, rotation: {}},
+        {timestamp: 250, position: {}, rotation: {}}
+      ]
+    });
     component.tick(150, 50);
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -436,6 +436,27 @@ suite('motion-capture-recorder', function () {
       component.saveCapture();
     });
   });
+
+  /**
+   * In manual motion capture (i.e., not avatar recording), the trigger is used to
+   * toggle recording. In avatar recording, trigger should not affect recording.
+   */
+  test('triggerdown does not affect avatar recording', function (done) {
+    assert.equal(component.recordedEvents.length, 0);
+    component.tick(100);
+    component.isRecording = true;
+    el.emit('buttonchanged', {id: 1, state: {value: 0}});
+    setTimeout(() => {
+      component.tick(100);
+      el.emit('buttonchanged', {id: 1, state: {value: 1}});
+      setTimeout(() => {
+        component.tick(100);
+        assert.equal(component.recordedEvents.length, 2);
+        assert.equal(component.recordedPoses.length, 2);
+        done();
+      });
+    });
+  });
 });
 
 suite('motion-capture-replayer', function () {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -323,9 +323,8 @@ suite('motion-capture-recorder', function () {
       setTimeout(() => {
         assert.equal(component.recordedEvents.length, 1);
         assert.equal(component.recordedEvents[0].name, 'axismove');
-        assert.shallowDeepEqual(component.recordedEvents[0].detail, {
-          id: 'foo', axis: {x: 1, y: 1}
-        });
+        assert.shallowDeepEqual(component.recordedEvents[0].detail,
+                                {id: 'foo', axis: {x: 1, y: 1}});
         assert.equal(component.recordedEvents[0].timestamp, 100);
         done();
       });
@@ -335,11 +334,12 @@ suite('motion-capture-recorder', function () {
       assert.equal(component.recordedEvents.length, 0);
       component.tick(100);
       component.isRecording = true;
-      el.emit('buttonchanged', {id: 'foo', state: true});
+      el.emit('buttonchanged', {id: 'foo', state: {value: 1}});
       setTimeout(() => {
         assert.equal(component.recordedEvents.length, 1);
         assert.equal(component.recordedEvents[0].name, 'buttonchanged');
-        assert.shallowDeepEqual(component.recordedEvents[0].detail, {id: 'foo', state: true});
+        assert.shallowDeepEqual(component.recordedEvents[0].detail,
+                                {id: 'foo', state: {value: 1}});
         assert.equal(component.recordedEvents[0].timestamp, 100);
         done();
       });
@@ -349,11 +349,12 @@ suite('motion-capture-recorder', function () {
       assert.equal(component.recordedEvents.length, 0);
       component.tick(100);
       component.isRecording = true;
-      el.emit('buttonup', {id: 'foo', state: true});
+      el.emit('buttonup', {id: 'foo', state: {value: 1}});
       setTimeout(() => {
         assert.equal(component.recordedEvents.length, 1);
         assert.equal(component.recordedEvents[0].name, 'buttonup');
-        assert.shallowDeepEqual(component.recordedEvents[0].detail, {id: 'foo', state: true});
+        assert.shallowDeepEqual(component.recordedEvents[0].detail,
+                                {id: 'foo', state: {value: 1}});
         assert.equal(component.recordedEvents[0].timestamp, 100);
         done();
       });
@@ -363,11 +364,12 @@ suite('motion-capture-recorder', function () {
       assert.equal(component.recordedEvents.length, 0);
       component.tick(100);
       component.isRecording = true;
-      el.emit('buttondown', {id: 'foo', state: true});
+      el.emit('buttondown', {id: 'foo', state: {value: 1}});
       setTimeout(() => {
         assert.equal(component.recordedEvents.length, 1);
         assert.equal(component.recordedEvents[0].name, 'buttondown');
-        assert.shallowDeepEqual(component.recordedEvents[0].detail, {id: 'foo', state: true});
+        assert.shallowDeepEqual(component.recordedEvents[0].detail,
+                                {id: 'foo', state: {value: 1}});
         assert.equal(component.recordedEvents[0].timestamp, 100);
         done();
       });
@@ -377,11 +379,12 @@ suite('motion-capture-recorder', function () {
       assert.equal(component.recordedEvents.length, 0);
       component.tick(100);
       component.isRecording = true;
-      el.emit('touchstart', {id: 'foo', state: true});
+      el.emit('touchstart', {id: 'foo', state: {value: 1}});
       setTimeout(() => {
         assert.equal(component.recordedEvents.length, 1);
         assert.equal(component.recordedEvents[0].name, 'touchstart');
-        assert.shallowDeepEqual(component.recordedEvents[0].detail, {id: 'foo', state: true});
+        assert.shallowDeepEqual(component.recordedEvents[0].detail,
+                                {id: 'foo', state: {value: 1}});
         assert.equal(component.recordedEvents[0].timestamp, 100);
         done();
       });
@@ -391,11 +394,12 @@ suite('motion-capture-recorder', function () {
       assert.equal(component.recordedEvents.length, 0);
       component.tick(100);
       component.isRecording = true;
-      el.emit('touchend', {id: 'foo', state: true});
+      el.emit('touchend', {id: 'foo', state: {value: 1}});
       setTimeout(() => {
         assert.equal(component.recordedEvents.length, 1);
         assert.equal(component.recordedEvents[0].name, 'touchend');
-        assert.shallowDeepEqual(component.recordedEvents[0].detail, {id: 'foo', state: true});
+        assert.shallowDeepEqual(component.recordedEvents[0].detail,
+                                {id: 'foo', state: {value: 1}});
         assert.equal(component.recordedEvents[0].timestamp, 100);
         done();
       });
@@ -457,6 +461,11 @@ suite('motion-capture-recorder', function () {
       });
     });
   });
+
+  test('handles empty data (e.g., one controller not tracking)', function () {
+    component.startRecording();
+    component.stopRecording();
+  });
 });
 
 suite('motion-capture-replayer', function () {
@@ -499,7 +508,7 @@ suite('motion-capture-replayer', function () {
   test('plays events', function (done) {
     el.addEventListener('buttondown', function (evt) {
       assert.equal(evt.detail.id, 'foo');
-      assert.ok(evt.detail.state);
+      assert.equal(evt.detail.state.value, 1);
       setTimeout(() => {
         component.tick(200, 50);
       });
@@ -516,15 +525,15 @@ suite('motion-capture-replayer', function () {
 
     el.addEventListener('touchend', function (evt) {
       assert.equal(evt.detail.id, 'baz');
-      assert.ok(evt.detail.state);
+      assert.equal(evt.detail.state.value, 1);
       done();
     });
 
     component.startReplaying({
       events: [
-        {timestamp: 100, name: 'buttondown', detail: {id: 'foo', state: true}},
+        {timestamp: 100, name: 'buttondown', detail: {id: 'foo', state: {value: 1}}},
         {timestamp: 200, name: 'axismove', detail: {id: 'bar', axis: {x: 1, y: 1}}},
-        {timestamp: 250, name: 'touchend', detail: {id: 'baz', state: true}}
+        {timestamp: 250, name: 'touchend', detail: {id: 'baz', state: {value: 1}}}
       ],
       poses: [
         {timestamp: 100, position: {}, rotation: {}},
@@ -533,5 +542,12 @@ suite('motion-capture-replayer', function () {
       ]
     });
     component.tick(150, 50);
+  });
+
+  test('handles empty data (e.g., one controller not tracking)', function () {
+    component.startReplaying({
+      events: [],
+      poses: []
+    });
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -275,6 +275,18 @@ suite('avatar-replayer', function () {
       done();
     });
   });
+
+  test('loads recording from external file', (done) => {
+    sceneEl.addEventListener('avatarreplayerstart', () => {
+      assert.ok(component.isReplaying);
+      assert.ok(component.replayData);
+      done();
+    });
+    sceneEl.setAttribute('avatar-replayer', {
+      src: '/base/tests/assets/test.json',
+      loop: false
+    });
+  });
 });
 
 suite('motion-capture-recorder', function () {


### PR DESCRIPTION
Tested avatar recording on Firefox Nightly:

**Changes:**

- Allow specifying recording from query parameter. This required some refactoring:
  - Let `avatar-replayer` decide where to source its recording data (localStorage, data.src, queryParam).
  - `avatar-recorder` only calls `avatar-replayer.startReplaying(data)` manually after a recording.
  - On initialization with autoplay, `avatar-recorder` will set `avatar-replayer` without anything else, letting `avatar-replayer` handle the replaying.
- Update tests and docs.

**Bug Fixes:**

- Fixed buttonchanged event recording since `evt.detail.state` was a non-serializable object.
- Fixed avatar recording. Before we were mapping controller trigger to toggle recording for the strokes/Pac Man use case. I temporarily commented it out.
- Fixed replay on empty data (i.e., one of my controllers not tracking).

**Style:**

- More renames from `play` -> `replay`.
- Simplify default recording file name a bit (remove timestamp, lowercase) for easier management, OSes will append a number for duplicated file names.